### PR TITLE
WeatherData 넣기 성공 및 업데이트에 날씨 저장 로직 달았음, 캘린더를 위한 메모 작성한 날짜 추출 로직 구현

### DIFF
--- a/client/src/api/dailyData.ts
+++ b/client/src/api/dailyData.ts
@@ -1,17 +1,10 @@
 import axios from "axios";
 import { getToken } from "../supabase";
-import { todoData } from "../type";
+import { todoData, weatherDataToSave } from "../type";
 
 export const getDailyData = async () => {
   try {
     const token = await getToken();
-    console.log(token);
-
-    if (!token) {
-      alert("로그인이 필요합니다.");
-      return { data: null };
-    }
-
     const response = await axios.get(
       "http://localhost:3000/DailyData", // NestJS 서버의 엔드포인트
       {
@@ -32,13 +25,6 @@ export const getDailyData = async () => {
 export const createDailyData = async () => {
   try {
     const token = await getToken();
-
-    if (!token) {
-      alert("로그인이 필요합니다.");
-      return { data: null };
-    }
-
-    //추후에 여기 빈 body안에 로컬스토리지 값을 넣던가 해도 될듯 자동 저장기능으로
     const response = await axios.post(
       "http://localhost:3000/DailyData",
       {},
@@ -49,25 +35,24 @@ export const createDailyData = async () => {
       }
     );
     return response;
+
+    //추후에 여기 빈 body안에 로컬스토리지 값을 넣던가 해도 될듯 자동 저장기능으로
   } catch (err) {
-    console.log(err);
+    throw new Error("페칭에 실패했습니다.");
   }
 };
 
 export const updateDailyData = async (
+  weatherDataToSave: weatherDataToSave,
   todoDataArray: todoData[],
   memoData: string
 ) => {
   try {
     const token = await getToken();
-
-    if (!token) {
-      alert("로그인이 필요합니다.");
-      return { data: null };
-    }
     const response = await axios.patch(
       "http://localhost:3000/DailyData",
       {
+        weatherDataToSave: weatherDataToSave,
         todoDataArray: todoDataArray,
         memoData: memoData,
       },
@@ -81,5 +66,24 @@ export const updateDailyData = async (
     return response;
   } catch (error: any) {
     console.log("Updating Faild", error);
+  }
+};
+export const getMonthlyDailyData = async () => {
+  //month를 받아서 해당 달에 해당 유저가 쓴 글에 대해서 정보를 받는다.
+  //이후 이를 바탕으로 getDailyData에 date를 보내서 해당 유저의 해당 날짜 글을 확인도 가능
+  try {
+    const token = await getToken();
+    const response = await axios.get(
+      "http://localhost:3000/DailyData/month", // NestJS 서버의 엔드포인트
+      {
+        headers: {
+          Authorization: `Bearer ${token}`, // 헤더에 Authorization 추가
+        },
+      }
+    );
+    const diaryDates = response.data.map((item: { date: string }) => item.date); // 날짜 배열 추출
+    return diaryDates as string[]; //["2025-01-03", "2025-01-05"]형식
+  } catch (err) {
+    console.log(err);
   }
 };

--- a/client/src/components/TodayInformation.tsx
+++ b/client/src/components/TodayInformation.tsx
@@ -5,6 +5,7 @@ import { todoData, weatherDataToSave } from "../type";
 import {
   createDailyData,
   getDailyData,
+  getMonthlyDailyData,
   updateDailyData,
 } from "../api/dailyData";
 import { getToken } from "../supabase";
@@ -16,8 +17,9 @@ export default function TodayInformation() {
   //memoData -> 옆의 메모장
   const [memoData, setMemoData] = useState<string>("");
   //저장할 weatherData -> 프롭스로 weatherAPI에 전달하니까 거기서 setWeatherDataToSave로 저장
-  const [weatherDataToSave, setWeatherDataToSave] =
-    useState<weatherDataToSave | null>(null);
+  const [weatherDataToSave, setWeatherDataToSave] = useState<
+    weatherDataToSave | object
+  >({});
 
   //컴포넌트 상태에 관한 것
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +40,10 @@ export default function TodayInformation() {
         setIsLoading(true);
         const response = await getDailyData();
 
-        //여기서 서버의 데이터를 가져오면 됨
+        //이건 한번 해당 유저의 해당 달에 쓴 데이터를 뽑는 로직을 짜봄
+        //month를 받아서 이를 적절히 넘겨줘야지 가능하다.
+        const response2 = await getMonthlyDailyData();
+        console.log(response2);
 
         if (response && response.data) {
           setTodoDataArray(response.data.todoData as todoData[]);
@@ -46,11 +51,11 @@ export default function TodayInformation() {
         } else {
           //현재 오늘 데이터가 존재하지 않는 경우!
           //일단은 바로 오늘 데이터를 생성해놓는 걸로 했는데, 이거 버튼식으로 바꿔도 좋을듯
-          if (weatherDataToSave) {
-            console.log(weatherDataToSave);
-            const response = await createDailyData();
-            console.log(response);
-          }
+          //여기까지 날씨 데이터를 못 받아오는 문제가 있다.
+          //일단 메모를 저장하면 그 동안에는 무조건 날씨는 받아오므로 업데이트에 날씨 보냄
+          //여기에 어떻게 처리를 해주면 좋을듯
+          const response = await createDailyData();
+          console.log(response);
         }
         setIsLoading(false);
       } catch (err) {
@@ -68,7 +73,11 @@ export default function TodayInformation() {
   const updatingHandler = () => {
     const func = async () => {
       try {
-        const response = await updateDailyData(todoDataArray, memoData);
+        const response = await updateDailyData(
+          weatherDataToSave as weatherDataToSave,
+          todoDataArray,
+          memoData
+        );
         if (response) {
           alert("저장되었습니다!");
         }

--- a/server/src/daily-data/daily-data.controller.ts
+++ b/server/src/daily-data/daily-data.controller.ts
@@ -9,6 +9,10 @@ export class DailyDataController {
   async getDailyData(@Headers('Authorization') authHeader: string) {
     return await this.DailyDataService.getDailyData(authHeader);
   }
+  @Get('month')
+  async getMonthlyDailyData(@Headers('Authorization') authHeader: string) {
+    return await this.DailyDataService.getMonthlyDailyData(authHeader);
+  }
 
   @Post()
   async postDailyData(@Headers('Authorization') authHeader: string) {

--- a/server/src/daily-data/daily-data.service.ts
+++ b/server/src/daily-data/daily-data.service.ts
@@ -86,9 +86,10 @@ export class DailyDataService {
       const today = new Date().toISOString().split('T')[0];
       const user = await this.getUserFromAuthHeader(authHeader);
       //supabase fetch
-      const { data, error } = await this.supabase
+      const { error } = await this.supabase
         .from('DailyData')
         .update({
+          weatherData: body.weatherDataToSave,
           todoData: body.todoDataArray,
           memoData: body.memoData,
         })
@@ -100,6 +101,27 @@ export class DailyDataService {
       }
     } catch (err) {
       console.log('Updating Connection Error ', err);
+    }
+  }
+  //Calender 전용
+  async getMonthlyDailyData(@Headers('Authorization') authHeader: string) {
+    try {
+      //조건 : 해당 유저이고, todoData가 있긴 해야한다.
+      const user = await this.getUserFromAuthHeader(authHeader);
+      const { data, error } = await this.supabase
+        .from('DailyData')
+        .select('date')
+        .eq('userId', user.id)
+        .neq('weatherData', null)
+        .gte('date', '2025-01-01')
+        .lte('date', '2025-01-31');
+      if (error) {
+        throw new Error(error.message);
+      }
+      console.log(data);
+      return data;
+    } catch (err) {
+      console.log(err);
     }
   }
 }


### PR DESCRIPTION
WeatherData에 대한 고민이 상당했다. 글 생성시에 넣을 수는 없었다. 왜냐하면 그 전에 날씨 데이터가 도착하지 않는다. 물론 글 생성을 버튼을 통해서 좀 날씨 데이터가 들어온 후에 진행한다면 가능하긴 하다만, 일단은 그렇게 만들지는 않았고 로그인 하고 오늘 데이터 없으면 만들어지는 건 동일하지만, weatherData는 업데이트 할 때 마다 같이 업데이트 되는 형태로 만들었다. 이를 활용해서 **weatherData가 존재한다 -> 메모를 업데이트 했다 -> 뭔가를 작성했다.** 까지 **연결시킬 수 있게 되었고 결국 calender에 도입될 월 별 메모 작성한 날짜 데이터 추출 서비스까지 구현했다.** 이로써 calender까지 연결시킬 준비는 완료됐고, UI에 좀 신경을 써도 되는 단계에 도착했다. 또한 Calender를 위한 getDailyData, month를 어떻게 보낼지 React Calender가 최선인지에 대해 생각해보자.